### PR TITLE
Fix session variable name for message type

### DIFF
--- a/src/Views/alerts.blade.php
+++ b/src/Views/alerts.blade.php
@@ -3,7 +3,7 @@
         swal({
             title: "{{ session('flash_message.title') }}",
             text:  "{{ session('flash_message.message') }}",
-            type: "{{ session('flash_message.level') }}",
+            type: "{{ session('flash_message.type') }}",
             timer: 2500,
             showConfirmButton: false
         });
@@ -15,7 +15,7 @@
         swal({
             title: "{{ session('flash_message_overlay.title') }}",
             text:  "{{ session('flash_message_overlay.message') }}",
-            type: "{{ session('flash_message_overlay.level') }}",
+            type: "{{ session('flash_message_overlay.type') }}",
             confirmButtonText: 'Ok'
         });
     </script>


### PR DESCRIPTION
This fixes the correct display of a flash message type.

Currently the session variable name that is referenced in the Blade view is "level" whereas "type" is set in the Flash class so the message type and subsequent animation is not correctly displayed. This PR changes the session variable name referenced in the view to "type" as is set by the class.