### PR TITLE
[Suggestion] Special chars like äöü will be escaped and are not readable anymore

### DIFF
--- a/src/Views/alerts.blade.php
+++ b/src/Views/alerts.blade.php
@@ -1,8 +1,8 @@
 @if (session()->has('flash_message'))
     <script>
         swal({
-            title: "{{ session('flash_message.title') }}",
-            text:  "{{ session('flash_message.message') }}",
+            title: "{!! session('flash_message.title') !!}",
+            text:  "{!! session('flash_message.message') !!}",
             type: "{{ session('flash_message.type') }}",
             timer: 2500,
             showConfirmButton: false

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -1,10 +1,13 @@
 <?php
-
-function alert($title = null, $message = null)
+	
+if(!function_exists ('alert')) 
 {
-    $flash = app('Infinety\SweetAlert\Flash');
-    if (func_num_args() == 0) {
-        return $flash;
-    }
-    return $flash->info($title, $message);
+	function alert($title = null, $message = null)
+	{
+	    $flash = app('Infinety\SweetAlert\Flash');
+	    if (func_num_args() == 0) {
+	        return $flash;
+	    }
+	    return $flash->info($title, $message);
+	}
 }


### PR DESCRIPTION
I use you package for a multilang Webpage, there I use chars like öäü. In order the output in the view will be escaped it could show like this:
![image](https://cloud.githubusercontent.com/assets/4414498/12109324/1d8b926c-b381-11e5-86f1-a97d4118665e.png)

Maybe we do not escape and are further be able to use formattings like bold etc?